### PR TITLE
new: Pass --user to ssh command

### DIFF
--- a/remotepy/instance.py
+++ b/remotepy/instance.py
@@ -329,6 +329,9 @@ def connect(
         "-p",
         help="Port forwarding configuration (local:remote)",
     ),
+    user: str = typer.Option(
+        "ubuntu", "--user", "-u", help="User to be used for ssh connection."
+    ),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose mode"),
 ):
     """
@@ -404,7 +407,7 @@ def connect(
 
     # Connect via SSH
 
-    subprocess.run(["ssh"] + arguments + [f"ubuntu@{get_instance_dns(instance_id)}"])
+    subprocess.run(["ssh"] + arguments + [f"{user}@{get_instance_dns(instance_id)}"])
 
 
 @app.command()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = remotepy
-version = 0.1.2
+version = 0.1.3
 author = Matthew Upson
 author_email = matthew.a.upson@gmail.com
 description = Utility for managing ec2 instances

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -33,5 +33,5 @@ def test_list(test_config):
     assert result.exit_code == 0
     assert "Name" in result.stdout
     assert "InstanceId" in result.stdout
-    assert "PublicIpAddress" in result.stdout
+    assert "PublicDnsName" in result.stdout
     assert "Status" in result.stdout


### PR DESCRIPTION
Allows a user to be specified when calling the ssh command.

This will help when we are dealing with multiple user accounts on an instance.

Defaults to ubuntu if none are specified.
