### PR TITLE
Add remote to PyPi

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Create a virtual environment and install the package
 ```
 virtualenv - -python 3.8 venv
 source venv/bin/activate
-pip install ".[tests]"
+pip install ".[dev]"
 ```
 
 # Run tests
@@ -77,3 +77,12 @@ pip install ".[tests]"
 ```
 pytest
 ```
+
+# PyPi
+
+```
+python -m build
+twine upload dist/
+```
+
+Note that you need to setup up authentication to PyPi for this work work.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = remotepy
-version = 0.1.8
+version = 0.1.9
 author = Matthew Upson
 author_email = matthew.a.upson@gmail.com
 description = Utility for managing ec2 instances

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,4 +29,4 @@ test =
 
 [options.entry_points]
 console_scripts =
-    remotepy = remotepy.cli:app
+    remote = remotepy.cli:app

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,11 +21,13 @@ install_requires =
 python_requires = >= 3.6
 
 [options.extras_require]
-test = 
+dev = 
     pytest
     tox
     flake8
     black
+    build
+    twine
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = remotepy
+name = remote
 version = 0.1.9
 author = Matthew Upson
 author_email = matthew.a.upson@gmail.com


### PR DESCRIPTION
Fixes #18 

⚠️ Remote rename needs to merge first. Also the package has not been uploaded yet, we need to agree if we will use Mantis account or you want to create an account to upload it under your username.