### PR TITLE
Splits CI into modules

### DIFF
--- a/remotepy/__main__.py
+++ b/remotepy/__main__.py
@@ -1,0 +1,16 @@
+from remotepy.ami import app as ami_app
+from remotepy.config import app as config_app
+from remotepy.instance import app as app
+from remotepy.snapshot import app as snapshot_app
+from remotepy.volume import app as volume_app
+
+# This means that the instance app is the default app, so we don't need to run
+# remote instance, we can just run remote
+
+app.add_typer(ami_app, name="ami")
+app.add_typer(config_app, name="config")
+app.add_typer(snapshot_app, name="snapshot")
+app.add_typer(volume_app, name="volume")
+
+if __name__ == "__main__":
+    app()

--- a/remotepy/ami.py
+++ b/remotepy/ami.py
@@ -1,0 +1,247 @@
+import random
+import string
+
+import typer
+import wasabi
+
+from remotepy.config import cfg
+from remotepy.utils import (
+    ec2_client,
+    get_account_id,
+    get_instance_id,
+    get_instance_name,
+)
+
+app = typer.Typer()
+
+
+@app.command()
+def create(
+    instance_name: str = typer.Option(None, help="Instance name"),
+    name: str = typer.Option(None, help="AMI name"),
+    description: str = typer.Option(None, help="Description"),
+):
+    """
+    Create an Amazon Machine Image (AMI) from a specified EC2 instance.
+
+    The function takes as input the name of an EC2 instance, the desired name for the AMI, and a description.
+    It sends a request to the AWS EC2 service to create an AMI from the specified instance.
+    If the AMI creation is successful, it returns the ID of the created AMI.
+
+    Parameters:
+    instance_name: str, optional
+        The name of the EC2 instance from which to create the AMI.
+        If not specified, the name of the current instance is used.
+
+    name: str, optional
+        The desired name for the AMI.
+
+    description: str, optional
+        A description for the AMI.
+
+    Returns:
+    None
+
+    Example usage:
+        python remotepy/instance.py create_ami --instance_name my-instance --name my-ami --description "My first AMI"
+
+    """
+
+    if not instance_name:
+        instance_name = get_instance_name(cfg)
+    instance_id = get_instance_id(instance_name)
+
+    ami = ec2_client.create_image(
+        InstanceId=instance_id,
+        Name=name,
+        Description=description,
+        NoReboot=True,
+    )
+
+    typer.secho(f"AMI {ami['ImageId']} created", fg=typer.colors.GREEN)
+
+
+@app.command("ls")
+@app.command("list")
+def list():
+    """
+    List all Amazon Machine Images (AMIs) owned by the current account.
+
+    This function queries AWS EC2 to get details of all AMIs that are owned by the current AWS account.
+    It formats the response data into a tabular form and displays it in the console.
+    The returned table includes the following columns: ImageId, Name, State, and CreationDate.
+
+    Example usage:
+        python remotepy/instance.py list_amis
+    """
+    account_id = get_account_id()
+
+    amis = ec2_client.describe_images(
+        Owners=[account_id],
+    )
+
+    header = ["ImageId", "Name", "State", "CreationDate"]
+    aligns = ["l", "l", "l", "l"]
+    data = []
+
+    for ami in amis["Images"]:
+        data.append(
+            [
+                ami["ImageId"],
+                ami["Name"],
+                ami["State"],
+                ami["CreationDate"],
+            ]
+        )
+
+    # Format table using wasabi
+    formatted = wasabi.table(data, header=header, divider=True, aligns=aligns)
+    typer.secho(formatted, fg=typer.colors.YELLOW)
+
+
+def get_launch_template_id(launch_template_name: str):
+    """
+    Get the launch template ID corresponding to a given launch template name.
+
+    This function queries AWS EC2 to get details of all launch templates with the specified name.
+    It then retrieves and returns the ID of the first matching launch template.
+
+    Args:
+        launch_template_name (str): The name of the launch template.
+
+    Returns:
+        str: The ID of the launch template.
+
+    Example usage:
+        template_id = get_launch_template_id("my-template-name")
+    """
+    launch_templates = ec2_client.describe_launch_templates(
+        Filters=[{"Name": "tag:Name", "Values": [launch_template_name]}]
+    )
+
+    launch_template_id = launch_templates["LaunchTemplates"][0]["LaunchTemplateId"]
+
+    return launch_template_id
+
+
+@app.command()
+def list_launch_templates():
+    """
+    List all launch templates available in the AWS EC2.
+
+    This function queries AWS EC2 to get details of all available launch templates.
+    It formats the response data into a tabular form and displays it in the console.
+    The returned table includes the following columns: Number, LaunchTemplateId, LaunchTemplateName, and Version.
+
+    Returns:
+        dict: The full response from the AWS EC2 describe_launch_templates call.
+
+    Example usage:
+        python remotepy/instance.py list_launch_templates
+    """
+    launch_templates = ec2_client.describe_launch_templates()
+
+    header = ["Number", "LaunchTemplateId", "LaunchTemplateName", "Version"]
+    aligns = ["l"] * len(header)
+    data = []
+
+    for i, launch_template in enumerate(launch_templates["LaunchTemplates"], 1):
+        data.append(
+            (
+                i,
+                launch_template["LaunchTemplateId"],
+                launch_template["LaunchTemplateName"],
+                launch_template["LatestVersionNumber"],
+            )
+        )
+
+    # Format table using wasabi
+    formatted = wasabi.table(data, header=header, divider=True, aligns=aligns)
+    typer.secho(formatted, fg=typer.colors.YELLOW)
+
+    return launch_templates
+
+
+@app.command()
+def launch(
+    name: str = typer.Option(None, help="Name of the instance to be launched"),
+    launch_template: str = typer.Option(None, help="Launch template name"),
+    version: str = typer.Option("$Latest", help="Launch template version"),
+):
+    """
+    Launch an AWS EC2 instance based on a launch template.
+
+    This function will launch an instance using the specified launch template and version.
+    If no launch template is provided, the function will list all available launch templates and
+    prompt the user to select one.
+
+    The name of the instance can be specified with the --name option. If not provided,
+    the function will prompt the user for the name and provide a suggested name based on
+    the launch template name appended with a random alphanumeric string.
+
+    Example usage:
+    python remotepy/instance.py launch --launch_template my-launch-template --version 2
+
+    Parameters:
+    name: The name of the instance to be launched. This will be used as a tag for the instance.
+    launch_template: The name of the launch template to use.
+    version: The version of the launch template to use. Default is the latest version.
+    """
+
+    # if no launch template is specified, list all the launch templates
+
+    if not launch_template:
+        typer.secho("Please specify a launch template", fg=typer.colors.RED)
+        typer.secho("Available launch templates:", fg=typer.colors.YELLOW)
+        launch_templates = list_launch_templates()["LaunchTemplates"]
+        typer.secho("Select a launch template by number", fg=typer.colors.YELLOW)
+        launch_template_number = typer.prompt("Launch template", type=str)
+        launch_template = launch_templates[int(launch_template_number) - 1]
+        launch_template_name = launch_template["LaunchTemplateName"]
+        launch_template_id = launch_template["LaunchTemplateId"]
+
+        typer.secho(
+            f"Launch template {launch_template_name} selected", fg=typer.colors.YELLOW
+        )
+        typer.secho(
+            f"Defaulting to latest version: {launch_template['LatestVersionNumber']}",
+            fg=typer.colors.YELLOW,
+        )
+        typer.secho(
+            f"Launching instance based on launch template {launch_template_name}"
+        )
+
+    # if no name is specified, ask the user for the name
+
+    if not name:
+        random_string = "".join(
+            random.choices(string.ascii_letters + string.digits, k=6)
+        )
+        name_suggestion = launch_template_name + "-" + random_string
+        name = typer.prompt(
+            "Please enter a name for the instance", type=str, default=name_suggestion
+        )
+
+    # Launch the instance with the specified launch template, version, and name
+    instance = ec2_client.run_instances(
+        LaunchTemplate={"LaunchTemplateId": launch_template_id, "Version": version},
+        MaxCount=1,
+        MinCount=1,
+        TagSpecifications=[
+            {
+                "ResourceType": "instance",
+                "Tags": [
+                    {"Key": "Name", "Value": name},
+                ],
+            },
+        ],
+    )
+
+    typer.secho(
+        f"Instance {instance['Instances'][0]['InstanceId']} with name '{name}' launched",
+        fg=typer.colors.GREEN,
+    )
+
+
+if __name__ == "__main__":
+    app()

--- a/remotepy/cli.py
+++ b/remotepy/cli.py
@@ -1,7 +1,0 @@
-from remotepy.config import app as config_app
-from remotepy.instance import app as app
-
-app.add_typer(config_app, name="config")
-
-if __name__ == "__main__":
-    app()

--- a/remotepy/config.py
+++ b/remotepy/config.py
@@ -1,12 +1,17 @@
 import configparser
 import os
+from typing import Optional
 
 import typer
 import wasabi
 
+from remotepy.utils import get_instance_ids, get_instance_info, get_instances
+
 CONFIG_PATH = os.path.join(
     os.path.expanduser("~"), ".config", "remote.py/", "config.ini"
 )
+cfg = configparser.ConfigParser()
+cfg.read(CONFIG_PATH)
 
 app = typer.Typer()
 
@@ -63,44 +68,69 @@ def show(config_path: str = typer.Option(CONFIG_PATH, "--config", "-c")):
 
 @app.command()
 def add(
-    instance_name: str = typer.Argument(None, help="Instance name"),
+    instance_name: Optional[str] = typer.Argument(None),
     config_path: str = typer.Option(CONFIG_PATH, "--config", "-c"),
 ):
     """
-    Add a new default instance to the config file
+    Add a new default instance to the config file.
+
+    This function allows you to add a new default instance either by providing the name directly or
+    by selecting it from a list of currently running instances. Terminated instances are not included
+    in this list. If a name is directly provided, the function checks if an instance with this name
+    exists before setting it as the default.
+
+    Arguments:
+    config_path -- The path to the configuration file.
+    instance_name -- The name of the instance to add. This is an optional argument.
+                     If not provided, the function will prompt the user to select an instance from a list.
+
+    Returns:
+    None. But it modifies the configuration file with the new default instance.
     """
 
-    # Check whether the instance_name is already set in the config
+    if instance_name is None:
+        # No instance name provided. Fetch the list of currently running
+        # instances (excluding terminated ones)
 
-    if not instance_name:
+        instances = get_instances()
 
-        if cfg["DEFAULT"].get("instance_name"):
-            typer.secho(
-                f"Default instance already set as {cfg['DEFAULT']['instance_name']}",
-                fg=typer.colors.YELLOW,
-            )
+        # Get the instance ids for the instances
+        ids = get_instance_ids(instances)
 
-            # Ask if the user still wants to change the instance name
+        # Get other details like name, type etc for these instances
+        names, _, _, instance_types, _ = get_instance_info(instances)
 
-            add_new = typer.confirm("Do you want to add a new default instance?")
+        # Prepare a formatted string to display these instance details as a
+        # table
+        header = ["Number", "Name", "InstanceId", "Type"]
+        aligns = ["l", "l", "l", "l"]
+        data = [
+            (i, name, id, it)
+            for i, (name, id, it) in enumerate(zip(names, ids, instance_types), 1)
+        ]
 
-            if add_new:
-                instance_name = typer.prompt("Instance name")
+        # Print the instances table
+        formatted = wasabi.table(data, header=header, divider=True, aligns=aligns)
+        typer.secho(formatted, fg=typer.colors.YELLOW)
 
-        # If not default exists in the config, then prompt for instance name
+        # Prompt the user to select an instance from the table
+        instance_number = typer.prompt("Select a instance by number", type=int)
 
+        # Validate the user input
+
+        if 1 <= instance_number <= len(names):
+            # If the input is valid, set the instance name to the selected one
+            instance_name = names[instance_number - 1]
         else:
-            typer.secho("No default instance found", fg=typer.colors.YELLOW)
-            instance_name = typer.prompt("Set the default instance name")
+            # Invalid input. Display an error message and exit.
+            typer.secho("Invalid number. No changes made", fg=typer.colors.YELLOW)
 
-    # If the instance_name has been set, then add it to the config
+            return
 
-    if instance_name:
-        cfg.set("DEFAULT", "instance_name", instance_name)
-        write_config(cfg, config_path)
-        typer.secho(f"Default instance set to {instance_name}", fg=typer.colors.GREEN)
-    else:
-        typer.secho("No changes made", fg=typer.colors.YELLOW)
+    # If an instance name was directly provided or selected from the list, update the configuration file
+    cfg.set("DEFAULT", "instance_name", instance_name)
+    write_config(cfg, config_path)
+    typer.secho(f"Default instance set to {instance_name}", fg=typer.colors.GREEN)
 
 
 if __name__ == "__main__":

--- a/remotepy/instance.py
+++ b/remotepy/instance.py
@@ -1,208 +1,29 @@
-import configparser
+import random
+import string
 import subprocess
 import sys
 import time
-from datetime import datetime
 
-import boto3
 import typer
 import wasabi
 
-from remotepy.config import CONFIG_PATH
-
-msg = wasabi.Printer()
-cfg = configparser.ConfigParser()
-cfg.read(CONFIG_PATH)
+from remotepy.config import cfg
+from remotepy.utils import (
+    ec2_client,
+    get_instance_dns,
+    get_instance_id,
+    get_instance_ids,
+    get_instance_info,
+    get_instance_name,
+    get_instance_status,
+    get_instance_type,
+    get_instances,
+    get_launch_template_id,
+    is_instance_running,
+    msg,
+)
 
 app = typer.Typer()
-
-ec2_client = boto3.client("ec2")
-
-
-def get_account_id():
-    """Returns the caller id, this is the AWS account id not the AWS user id"""
-
-    return boto3.client("sts").get_caller_identity()["Account"]
-
-
-def get_instance_id(instance_name):
-    """Returns the id of the instance"""
-
-    instances = ec2_client.describe_instances(
-        Filters=[
-            {"Name": "tag:Name", "Values": [instance_name]},
-            {
-                "Name": "instance-state-name",
-                "Values": ["pending", "stopping", "stopped", "running"],
-            },
-        ]
-    )
-
-    if instances["Reservations"]:
-        if len(instances["Reservations"]) == 1:
-            return instances["Reservations"][0]["Instances"][0]["InstanceId"]
-        else:
-            typer.secho(
-                f"Multiple instances found with name {instance_name}",
-                fg=typer.colors.RED,
-            )
-            sys.exit(1)
-    else:
-        typer.secho(f"Instance {instance_name} not found", fg=typer.colors.RED)
-        sys.exit(1)
-
-
-def get_instance_status(instance_id: str = None):
-    """Returns the status of the instance"""
-
-    if instance_id:
-        return ec2_client.describe_instance_status(InstanceIds=[instance_id])
-    else:
-        return ec2_client.describe_instance_status()
-
-
-def get_instances():
-    """Returns information about all instances"""
-
-    return ec2_client.describe_instances()["Reservations"]
-
-
-def get_instance_dns(instance_id):
-    """Returns the public IP address of the instance"""
-
-    return ec2_client.describe_instances(InstanceIds=[instance_id])["Reservations"][0][
-        "Instances"
-    ][0]["PublicDnsName"]
-
-
-def get_instance_name():
-    """Returns the name of the instance as defined in the config file"""
-
-    if instance_name := cfg["DEFAULT"].get("instance_name"):
-        return instance_name
-    else:
-        typer.secho("Instance name not found in config file", fg=typer.colors.RED)
-        typer.secho("Run `remotepy config add` to add it", fg=typer.colors.RED)
-        sys.exit(1)
-
-
-def get_instance_info(
-    instances: list, name_filter: str = None, drop_nameless: bool = False
-):
-    """
-    Get all instance names for the given account from aws cli
-
-    Args:
-        instances: List of instances returned by get_instances()
-        name_filter: Filter to apply to the instance names. If not found in the
-            instance name, it will be excluded from the list.
-    """
-    names = []
-    public_dnss = []
-    statuses = []
-    instance_types = []
-    launch_times = []
-
-    for i in instances:
-        for instance in i["Instances"]:
-
-            # Check whether there is a Name tag, and break out of the loop
-            # if there is not. This is to avoid fetching information about
-            # instances that are part of kubernetes clusters, etc.
-
-            tags = {k["Key"]: k["Value"] for k in instance.get("Tags", [])}
-
-            if not tags or "Name" not in tags:
-                break
-            else:
-                names.append(tags["Name"])
-                public_dnss.append(instance["PublicDnsName"])
-
-                if (status := instance["State"]["Name"]) == "running":
-                    launch_time = instance["LaunchTime"].timestamp()
-                    launch_time = datetime.utcfromtimestamp(launch_time)
-                    launch_time = launch_time.strftime("%Y-%m-%d %H:%M:%S UTC")
-
-                else:
-                    launch_time = None
-                launch_times.append(launch_time)
-                statuses.append(status)
-                instance_types.append(instance["InstanceType"])
-
-    return names, public_dnss, statuses, instance_types, launch_times
-
-
-def get_instance_ids(instances):
-    """
-    Returns a list of instance ids extract from the output of get_instances()
-    """
-
-    return [i["Instances"][0]["InstanceId"] for i in instances]
-
-
-def is_instance_running(instance_id):
-    """Returns True if the instance is running"""
-
-    status = get_instance_status(instance_id)
-
-    if status["InstanceStatuses"]:
-        if status["InstanceStatuses"][0]["InstanceState"]["Name"] == "running":
-            return True
-        else:
-            return False
-
-
-def is_instance_stopped(instance_id):
-    """Returns True if the instance is stopped"""
-
-    status = get_instance_status(instance_id)
-
-    if status["InstanceStatuses"]:
-        if status["InstanceStatuses"][0]["InstanceState"]["Name"] == "stopped":
-            return True
-        else:
-            return False
-
-
-def get_instance_type(instance_id):
-    """Returns the instance type of the instance"""
-
-    return ec2_client.describe_instances(InstanceIds=[instance_id])["Reservations"][0][
-        "Instances"
-    ][0]["InstanceType"]
-
-
-def get_volume_ids(instance_id):
-    """Returns a list of volume ids attached to the instance"""
-
-    return [
-        i["VolumeId"]
-        for i in ec2_client.describe_volumes(
-            Filters=[{"Name": "attachment.instance-id", "Values": [instance_id]}]
-        )["Volumes"]
-    ]
-
-
-def get_volume_name(volume_id):
-    """Returns the name of the volume"""
-
-    volume = ec2_client.describe_volumes(VolumeIds=[volume_id])["Volumes"][0]
-
-    volume_name = ""
-
-    for tag in volume.get("Tags", []):
-        if tag["Key"] == "Name":
-            volume_name = tag["Value"]
-
-    return volume_name
-
-
-def get_snapshot_status(snapshot_id):
-    """Returns the status of the snapshot"""
-
-    return ec2_client.describe_snapshots(SnapshotIds=[snapshot_id])["Snapshots"][0][
-        "State"
-    ]
 
 
 @app.command("ls")
@@ -231,9 +52,7 @@ def list():
 
     # Return the status in a nicely formatted table
 
-    formatted = wasabi.table(
-        data, header=header, divider=True, aligns=aligns
-    )
+    formatted = wasabi.table(data, header=header, divider=True, aligns=aligns)
     typer.secho(formatted, fg=typer.colors.YELLOW)
 
 
@@ -244,7 +63,7 @@ def status(instance_name: str = typer.Argument(None, help="Instance name")):
     """
 
     if not instance_name:
-        instance_name = get_instance_name()
+        instance_name = get_instance_name(cfg)
     instance_id = get_instance_id(instance_name)
     typer.secho(
         f"Getting status of {instance_name} ({instance_id})", fg=typer.colors.YELLOW
@@ -290,7 +109,7 @@ def start(instance_name: str = typer.Argument(None, help="Instance name")):
     """
 
     if not instance_name:
-        instance_name = get_instance_name()
+        instance_name = get_instance_name(cfg)
     instance_id = get_instance_id(instance_name)
 
     if is_instance_running(instance_id):
@@ -314,7 +133,7 @@ def stop(instance_name: str = typer.Argument(None, help="Instance name")):
     """
 
     if not instance_name:
-        instance_name = get_instance_name()
+        instance_name = get_instance_name(cfg)
     instance_id = get_instance_id(instance_name)
 
     if not is_instance_running(instance_id):
@@ -360,7 +179,7 @@ def connect(
     """
 
     if not instance_name:
-        instance_name = get_instance_name()
+        instance_name = get_instance_name(cfg)
     max_attempts = 5
     sleep_duration = 20
     instance_id = get_instance_id(instance_name)
@@ -428,7 +247,9 @@ def connect(
 
     # Connect via SSH
 
-    subprocess.run(["ssh"] + arguments + [f"{user}@{get_instance_dns(instance_id)}"])
+    dns = get_instance_dns(instance_id)
+
+    subprocess.run(["ssh"] + arguments + [f"{user}@{dns}"])
 
 
 @app.command()
@@ -437,10 +258,10 @@ def type(
         None,
         help="Type of instance to convert to. If none, will print the current instance type.",
     ),
-    instance_name: str = typer.Argument(None, help="Instance name")
+    instance_name: str = typer.Argument(None, help="Instance name"),
 ):
     if not instance_name:
-        instance_name = get_instance_name()
+        instance_name = get_instance_name(cfg)
     instance_id = get_instance_id(instance_name)
     current_type = get_instance_type(instance_id)
 
@@ -465,7 +286,7 @@ def type(
             if is_instance_running(instance_id):
 
                 typer.secho(
-                    f"You can only change the type of a stopped instances",
+                    "You can only change the type of a stopped instances",
                     fg=typer.colors.RED,
                 )
 
@@ -523,176 +344,148 @@ def type(
         )
 
 
-@app.command()
-def list_volumes(instance_name: str = typer.Argument(None, help="Instance name")):
+def get_launch_template_id(launch_template_name: str):
     """
-    List the volumes and the instances they are attached to
-    """
+    Get the launch template ID corresponding to a given launch template name.
 
-    if not instance_name:
-        instance_name = get_instance_name()
-    typer.secho(
-        f"Listing volumes attached to instance {instance_name}", fg=typer.colors.YELLOW
+    This function queries AWS EC2 to get details of all launch templates with the specified name.
+    It then retrieves and returns the ID of the first matching launch template.
+
+    Args:
+        launch_template_name (str): The name of the launch template.
+
+    Returns:
+        str: The ID of the launch template.
+
+    Example usage:
+        template_id = get_launch_template_id("my-template-name")
+    """
+    launch_templates = ec2_client.describe_launch_templates(
+        Filters=[{"Name": "tag:Name", "Values": [launch_template_name]}]
     )
 
-    instance_id = get_instance_id(instance_name)
-    volumes = ec2_client.describe_volumes()
+    launch_template_id = launch_templates["LaunchTemplates"][0]["LaunchTemplateId"]
 
-    # Format table using wasabi
+    return launch_template_id
 
-    header = [
-        "Instance Name",
-        "Instance",
-        "Volume Name",
-        "VolumeId",
-        "Size",
-        "State",
-        "AvailabilityZone",
-    ]
-    aligns = ["l", "l", "l", "l", "l", "l", "l"]
+
+@app.command()
+def list_launch_templates():
+    """
+    List all launch templates available in the AWS EC2.
+
+    This function queries AWS EC2 to get details of all available launch templates.
+    It formats the response data into a tabular form and displays it in the console.
+    The returned table includes the following columns: Number, LaunchTemplateId, LaunchTemplateName, and Version.
+
+    Returns:
+        dict: The full response from the AWS EC2 describe_launch_templates call.
+
+    Example usage:
+        python remotepy/instance.py list_launch_templates
+    """
+    launch_templates = ec2_client.describe_launch_templates()
+
+    header = ["Number", "LaunchTemplateId", "LaunchTemplateName", "Version"]
+    aligns = ["l"] * len(header)
     data = []
 
-    # Get the volumes attached to instance
+    for i, launch_template in enumerate(launch_templates["LaunchTemplates"], 1):
+        data.append(
+            (
+                i,
+                launch_template["LaunchTemplateId"],
+                launch_template["LaunchTemplateName"],
+                launch_template["LatestVersionNumber"],
+            )
+        )
 
-    for volume in volumes["Volumes"]:
-        for attachment in volume["Attachments"]:
-            if attachment["InstanceId"] == instance_id:
-                data.append(
-                    [
-                        instance_name,
-                        instance_id,
-                        get_volume_name(volume["VolumeId"]),
-                        volume["VolumeId"],
-                        volume["Size"],
-                        volume["State"],
-                        volume["AvailabilityZone"],
-                    ]
-                )
-
+    # Format table using wasabi
     formatted = wasabi.table(data, header=header, divider=True, aligns=aligns)
     typer.secho(formatted, fg=typer.colors.YELLOW)
 
+    return launch_templates
+
 
 @app.command()
-def create_snapshot(
-    volume_id: str = typer.Option(None, help="Volume ID"),
-    name: str = typer.Option(None, help="Snapshot name"),
-    description: str = typer.Option(None, help="Description"),
+def launch(
+    name: str = typer.Option(None, help="Name of the instance to be launched"),
+    launch_template: str = typer.Option(None, help="Launch template name"),
+    version: str = typer.Option("$Latest", help="Launch template version"),
 ):
     """
-    Snapshot a volume
+    Launch an AWS EC2 instance based on a launch template.
+
+    This function will launch an instance using the specified launch template and version.
+    If no launch template is provided, the function will list all available launch templates and
+    prompt the user to select one.
+
+    The name of the instance can be specified with the --name option. If not provided,
+    the function will prompt the user for the name and provide a suggested name based on
+    the launch template name appended with a random alphanumeric string.
+
+    Example usage:
+    python remotepy/instance.py launch --launch_template my-launch-template --version 2
+
+    Parameters:
+    name: The name of the instance to be launched. This will be used as a tag for the instance.
+    launch_template: The name of the launch template to use.
+    version: The version of the launch template to use. Default is the latest version.
     """
 
-    snapshot = ec2_client.create_snapshot(
-        VolumeId=volume_id,
-        Description=description,
+    # if no launch template is specified, list all the launch templates
+
+    if not launch_template:
+        typer.secho("Please specify a launch template", fg=typer.colors.RED)
+        typer.secho("Available launch templates:", fg=typer.colors.YELLOW)
+        launch_templates = list_launch_templates()["LaunchTemplates"]
+        typer.secho("Select a launch template by number", fg=typer.colors.YELLOW)
+        launch_template_number = typer.prompt("Launch template", type=str)
+        launch_template = launch_templates[int(launch_template_number) - 1]
+        launch_template_name = launch_template["LaunchTemplateName"]
+        launch_template_id = launch_template["LaunchTemplateId"]
+
+        typer.secho(
+            f"Launch template {launch_template_name} selected", fg=typer.colors.YELLOW
+        )
+        typer.secho(
+            f"Defaulting to latest version: {launch_template['LatestVersionNumber']}",
+            fg=typer.colors.YELLOW,
+        )
+        typer.secho(
+            f"Launching instance based on launch template {launch_template_name}"
+        )
+
+    # if no name is specified, ask the user for the name
+
+    if not name:
+        random_string = "".join(
+            random.choices(string.ascii_letters + string.digits, k=6)
+        )
+        name_suggestion = launch_template_name + "-" + random_string
+        name = typer.prompt(
+            "Please enter a name for the instance", type=str, default=name_suggestion
+        )
+
+    # Launch the instance with the specified launch template, version, and name
+    instance = ec2_client.run_instances(
+        LaunchTemplate={"LaunchTemplateId": launch_template_id, "Version": version},
+        MaxCount=1,
+        MinCount=1,
         TagSpecifications=[
             {
-                "ResourceType": "snapshot",
-                "Tags": [{"Key": "Name", "Value": name}],
-            }
+                "ResourceType": "instance",
+                "Tags": [
+                    {"Key": "Name", "Value": name},
+                ],
+            },
         ],
     )
 
-    typer.secho(f"Snapshot {snapshot['SnapshotId']} created", fg=typer.colors.GREEN)
-
-
-@app.command()
-def list_snapshots(instance_name: str = typer.Argument(None, help="Instance name")):
-    """
-    List the snapshots
-    """
-
-    if not instance_name:
-        instance_name = get_instance_name()
-
     typer.secho(
-        f"Listing snapshots for instance {instance_name}", fg=typer.colors.YELLOW
+        f"Instance {instance['Instances'][0]['InstanceId']} with name '{name}' launched",
+        fg=typer.colors.GREEN,
     )
-
-    instance_id = get_instance_id(instance_name)
-    volume_ids = get_volume_ids(instance_id)
-
-    header = ["SnapshotId", "VolumeId", "State", "StartTime", "Description"]
-    aligns = ["l", "l", "l", "l", "l"]
-    data = []
-
-    for volume_id in volume_ids:
-
-        snapshots = ec2_client.describe_snapshots(
-            Filters=[{"Name": "volume-id", "Values": [volume_id]}]
-        )
-
-        for snapshot in snapshots["Snapshots"]:
-            data.append(
-                [
-                    snapshot["SnapshotId"],
-                    snapshot["VolumeId"],
-                    snapshot["State"],
-                    snapshot["StartTime"],
-                    snapshot["Description"],
-                ]
-            )
-
-    # Format table using wasabi
-
-    formatted = wasabi.table(data, header=header, divider=True, aligns=aligns)
-    typer.secho(formatted, fg=typer.colors.YELLOW)
-
-
-@app.command()
-def create_ami(
-    instance_name: str = typer.Option(None, help="Instance name"),
-    name: str = typer.Option(None, help="AMI name"),
-    description: str = typer.Option(None, help="Description"),
-):
-    """
-    Create AMI from Instance
-    """
-
-    if not instance_name:
-        instance_name = get_instance_name()
-    instance_id = get_instance_id(instance_name)
-
-    ami = ec2_client.create_image(
-        InstanceId=instance_id,
-        Name=name,
-        Description=description,
-        NoReboot=True,
-    )
-
-    typer.secho(f"AMI {ami['ImageId']} created", fg=typer.colors.GREEN)
-
-
-@app.command()
-def list_amis():
-    """
-    List AMIs
-    """
-    account_id = get_account_id()
-
-    amis = ec2_client.describe_images(
-        Owners=[account_id],
-    )
-
-    header = ["ImageId", "Name", "State", "CreationDate"]
-    aligns = ["l", "l", "l", "l"]
-    data = []
-
-    for ami in amis["Images"]:
-        data.append(
-            [
-                ami["ImageId"],
-                ami["Name"],
-                ami["State"],
-                ami["CreationDate"],
-            ]
-        )
-
-    # Format table using wasabi
-
-    formatted = wasabi.table(data, header=header, divider=True, aligns=aligns)
-    typer.secho(formatted, fg=typer.colors.YELLOW)
 
 
 if __name__ == "__main__":

--- a/remotepy/snapshot.py
+++ b/remotepy/snapshot.py
@@ -1,0 +1,84 @@
+import typer
+import wasabi
+
+from remotepy.config import cfg
+from remotepy.utils import (
+    ec2_client,
+    get_instance_id,
+    get_instance_name,
+    get_volume_ids,
+)
+
+app = typer.Typer()
+
+
+@app.command()
+def create(
+    volume_id: str = typer.Option(None, help="Volume ID"),
+    name: str = typer.Option(None, help="Snapshot name"),
+    description: str = typer.Option(None, help="Description"),
+):
+    """
+    Snapshot a volume
+    """
+
+    snapshot = ec2_client.create_snapshot(
+        VolumeId=volume_id,
+        Description=description,
+        TagSpecifications=[
+            {
+                "ResourceType": "snapshot",
+                "Tags": [{"Key": "Name", "Value": name}],
+            }
+        ],
+    )
+
+    typer.secho(f"Snapshot {snapshot['SnapshotId']} created", fg=typer.colors.GREEN)
+
+
+@app.command("ls")
+@app.command("list")
+def list(instance_name: str = typer.Argument(None, help="Instance name")):
+    """
+    List the snapshots
+    """
+
+    if not instance_name:
+        instance_name = get_instance_name(cfg)
+
+    typer.secho(
+        f"Listing snapshots for instance {instance_name}", fg=typer.colors.YELLOW
+    )
+
+    instance_id = get_instance_id(instance_name)
+    volume_ids = get_volume_ids(instance_id)
+
+    header = ["SnapshotId", "VolumeId", "State", "StartTime", "Description"]
+    aligns = ["l", "l", "l", "l", "l"]
+    data = []
+
+    for volume_id in volume_ids:
+
+        snapshots = ec2_client.describe_snapshots(
+            Filters=[{"Name": "volume-id", "Values": [volume_id]}]
+        )
+
+        for snapshot in snapshots["Snapshots"]:
+            data.append(
+                [
+                    snapshot["SnapshotId"],
+                    snapshot["VolumeId"],
+                    snapshot["State"],
+                    snapshot["StartTime"],
+                    snapshot["Description"],
+                ]
+            )
+
+    # Format table using wasabi
+
+    formatted = wasabi.table(data, header=header, divider=True, aligns=aligns)
+    typer.secho(formatted, fg=typer.colors.YELLOW)
+
+
+if __name__ == "__main__":
+    app()

--- a/remotepy/utils.py
+++ b/remotepy/utils.py
@@ -1,0 +1,227 @@
+import sys
+from configparser import ConfigParser
+from datetime import datetime
+
+import boto3
+import typer
+import wasabi
+
+msg = wasabi.Printer()
+
+app = typer.Typer()
+
+ec2_client = boto3.client("ec2")
+
+
+def get_account_id():
+    """Returns the caller id, this is the AWS account id not the AWS user id"""
+
+    return boto3.client("sts").get_caller_identity()["Account"]
+
+
+def get_instance_id(instance_name):
+    """Returns the id of the instance"""
+
+    instances = ec2_client.describe_instances(
+        Filters=[
+            {"Name": "tag:Name", "Values": [instance_name]},
+            {
+                "Name": "instance-state-name",
+                "Values": ["pending", "stopping", "stopped", "running"],
+            },
+        ]
+    )
+
+    if instances["Reservations"]:
+
+        if len(instances["Reservations"]) == 1:
+            return instances["Reservations"][0]["Instances"][0]["InstanceId"]
+        else:
+            typer.secho(
+                f"Multiple instances found with name {instance_name}",
+                fg=typer.colors.RED,
+            )
+            sys.exit(1)
+    else:
+        typer.secho(f"Instance {instance_name} not found", fg=typer.colors.RED)
+        sys.exit(1)
+
+
+def get_instance_status(instance_id: str = None):
+    """Returns the status of the instance"""
+
+    if instance_id:
+        return ec2_client.describe_instance_status(InstanceIds=[instance_id])
+    else:
+        return ec2_client.describe_instance_status()
+
+
+def get_instances(exclude_terminated: bool = False):
+    """
+    Get all instances, optionally excluding those in a 'terminated' state.
+    """
+
+    return ec2_client.describe_instances()["Reservations"]
+
+
+def get_instance_dns(instance_id):
+    """Returns the public IP address of the instance"""
+
+    return ec2_client.describe_instances(InstanceIds=[instance_id])["Reservations"][0][
+        "Instances"
+    ][0]["PublicDnsName"]
+
+
+def get_instance_name(cfg: ConfigParser):
+    """Returns the name of the instance as defined in the config file"""
+
+    if instance_name := cfg["DEFAULT"].get("instance_name"):
+        return instance_name
+    else:
+        typer.secho("Instance name not found in config file", fg=typer.colors.RED)
+        typer.secho("Run `remotepy config add` to add it", fg=typer.colors.RED)
+        sys.exit(1)
+
+
+def get_instance_info(
+    instances: list, name_filter: str = None, drop_nameless: bool = False
+):
+    """
+    Get all instance names for the given account from aws cli
+
+    Args:
+        instances: List of instances returned by get_instances()
+        name_filter: Filter to apply to the instance names. If not found in the
+            instance name, it will be excluded from the list.
+    """
+    names = []
+    public_dnss = []
+    statuses = []
+    instance_types = []
+    launch_times = []
+
+    for i in instances:
+        for instance in i["Instances"]:
+
+            # Check whether there is a Name tag, and break out of the loop
+            # if there is not. This is to avoid fetching information about
+            # instances that are part of kubernetes clusters, etc.
+
+            tags = {k["Key"]: k["Value"] for k in instance.get("Tags", [])}
+
+            if not tags or "Name" not in tags:
+                break
+            else:
+                names.append(tags["Name"])
+                public_dnss.append(instance["PublicDnsName"])
+
+                if (status := instance["State"]["Name"]) == "running":
+                    launch_time = instance["LaunchTime"].timestamp()
+                    launch_time = datetime.utcfromtimestamp(launch_time)
+                    launch_time = launch_time.strftime("%Y-%m-%d %H:%M:%S UTC")
+
+                else:
+                    launch_time = None
+                launch_times.append(launch_time)
+                statuses.append(status)
+                instance_types.append(instance["InstanceType"])
+
+    return names, public_dnss, statuses, instance_types, launch_times
+
+
+def get_instance_ids(instances):
+    """
+    Returns a list of instance ids extract from the output of get_instances()
+    """
+
+    return [i["Instances"][0]["InstanceId"] for i in instances]
+
+
+def is_instance_running(instance_id):
+    """Returns True if the instance is running"""
+
+    status = get_instance_status(instance_id)
+
+    if status["InstanceStatuses"]:
+        if status["InstanceStatuses"][0]["InstanceState"]["Name"] == "running":
+            return True
+        else:
+            return False
+
+
+def is_instance_stopped(instance_id):
+    """Returns True if the instance is stopped"""
+
+    status = get_instance_status(instance_id)
+
+    if status["InstanceStatuses"]:
+        if status["InstanceStatuses"][0]["InstanceState"]["Name"] == "stopped":
+            return True
+        else:
+            return False
+
+
+def get_instance_type(instance_id):
+    """Returns the instance type of the instance"""
+
+    return ec2_client.describe_instances(InstanceIds=[instance_id])["Reservations"][0][
+        "Instances"
+    ][0]["InstanceType"]
+
+
+def get_volume_ids(instance_id):
+    """Returns a list of volume ids attached to the instance"""
+
+    return [
+        i["VolumeId"]
+        for i in ec2_client.describe_volumes(
+            Filters=[{"Name": "attachment.instance-id", "Values": [instance_id]}]
+        )["Volumes"]
+    ]
+
+
+def get_volume_name(volume_id):
+    """Returns the name of the volume"""
+
+    volume = ec2_client.describe_volumes(VolumeIds=[volume_id])["Volumes"][0]
+
+    volume_name = ""
+
+    for tag in volume.get("Tags", []):
+        if tag["Key"] == "Name":
+            volume_name = tag["Value"]
+
+    return volume_name
+
+
+def get_snapshot_status(snapshot_id):
+    """Returns the status of the snapshot"""
+
+    return ec2_client.describe_snapshots(SnapshotIds=[snapshot_id])["Snapshots"][0][
+        "State"
+    ]
+
+
+def get_launch_template_id(launch_template_name: str):
+    """
+    Get the launch template ID corresponding to a given launch template name.
+
+    This function queries AWS EC2 to get details of all launch templates with the specified name.
+    It then retrieves and returns the ID of the first matching launch template.
+
+    Args:
+        launch_template_name (str): The name of the launch template.
+
+    Returns:
+        str: The ID of the launch template.
+
+    Example usage:
+        template_id = get_launch_template_id("my-template-name")
+    """
+    launch_templates = ec2_client.describe_launch_templates(
+        Filters=[{"Name": "tag:Name", "Values": [launch_template_name]}]
+    )
+
+    launch_template_id = launch_templates["LaunchTemplates"][0]["LaunchTemplateId"]
+
+    return launch_template_id

--- a/remotepy/volume.py
+++ b/remotepy/volume.py
@@ -1,0 +1,67 @@
+import typer
+import wasabi
+
+from remotepy.config import cfg
+from remotepy.utils import (
+    ec2_client,
+    get_instance_id,
+    get_instance_name,
+    get_volume_name,
+)
+
+app = typer.Typer()
+
+
+@app.command("ls")
+@app.command("list")
+def list(instance_name: str = typer.Argument(None, help="Instance name")):
+    """
+    List the volumes and the instances they are attached to
+    """
+
+    if not instance_name:
+        instance_name = get_instance_name(cfg)
+    typer.secho(
+        f"Listing volumes attached to instance {instance_name}", fg=typer.colors.YELLOW
+    )
+
+    instance_id = get_instance_id(instance_name)
+    volumes = ec2_client.describe_volumes()
+
+    # Format table using wasabi
+
+    header = [
+        "Instance Name",
+        "Instance",
+        "Volume Name",
+        "VolumeId",
+        "Size",
+        "State",
+        "AvailabilityZone",
+    ]
+    aligns = ["l", "l", "l", "l", "l", "l", "l"]
+    data = []
+
+    # Get the volumes attached to instance
+
+    for volume in volumes["Volumes"]:
+        for attachment in volume["Attachments"]:
+            if attachment["InstanceId"] == instance_id:
+                data.append(
+                    [
+                        instance_name,
+                        instance_id,
+                        get_volume_name(volume["VolumeId"]),
+                        volume["VolumeId"],
+                        volume["Size"],
+                        volume["State"],
+                        volume["AvailabilityZone"],
+                    ]
+                )
+
+    formatted = wasabi.table(data, header=header, divider=True, aligns=aligns)
+    typer.secho(formatted, fg=typer.colors.YELLOW)
+
+
+if __name__ == "__main__":
+    app()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = remotepy
-version = 0.1.10
+version = 0.2.0
 author = Matthew Upson
 author_email = matthew.a.upson@gmail.com
 description = Utility for managing ec2 instances
@@ -30,4 +30,4 @@ test =
 
 [options.entry_points]
 console_scripts =
-    remote = remotepy.cli:app
+    remote = remotepy.__main__:app


### PR DESCRIPTION
Resolves #23 

Splits the CI into a number of better organised modules:

```
instance
volume
snapshot
ami
config
```

The default instance remains instance, so the most commonly used functions can be accessed with just `remote <command>`, although we can easily change this.
