### PR TITLE
feat: Beautify CLI logo with centering, tagline, and version

### DIFF
--- a/remote/logo.py
+++ b/remote/logo.py
@@ -96,24 +96,32 @@ def get_version() -> str:
         return "0.0.0"
 
 
-def print_logo(show_version: bool = False) -> None:
-    """Print the logo with gradient colors.
+TAGLINE = "AWS EC2 Instance Management"
 
-    Args:
-        show_version: If True, display version info below the logo
-    """
+
+def print_logo() -> None:
+    """Print the centered logo with gradient colors, tagline, and version."""
     console = Console()
     lines = LOGO.strip().split("\n")
     total_lines = len(lines)
 
+    # Calculate logo width and terminal width for centering
+    logo_width = max(len(line) for line in lines)
+    terminal_width = console.width
+    padding = max(0, (terminal_width - logo_width) // 2)
+    pad_str = " " * padding
+
     styled_text = Text()
     for i, line in enumerate(lines):
         color = get_color_for_line(i, total_lines, FIRE_PALETTE)
-        styled_text.append(line + "\n", style=color)
+        styled_text.append(pad_str + line + "\n", style=color)
 
     console.print(styled_text, end="")
 
-    if show_version:
-        version = get_version()
-        console.print(f"  [dim]v{version}[/dim]")
-        console.print()
+    # Build tagline with version
+    version = get_version()
+    tagline_text = f"{TAGLINE}  v{version}"
+    tagline_padding = max(0, (terminal_width - len(tagline_text)) // 2)
+
+    console.print(" " * tagline_padding + f"[dim]{tagline_text}[/dim]")
+    console.print()  # Blank line for spacing

--- a/tests/test_logo.py
+++ b/tests/test_logo.py
@@ -60,11 +60,22 @@ class TestPrintLogo:
         lines = captured.out.strip().split("\n")
         assert len(lines) > 1
 
-    def test_print_logo_with_version(self, mocker, capsys):
+    def test_print_logo_shows_version(self, mocker, capsys):
         mocker.patch("remote.logo.get_version", return_value="1.2.3")
-        print_logo(show_version=True)
+        print_logo()
         captured = capsys.readouterr()
-        assert "1.2.3" in captured.out
+        assert "v1.2.3" in captured.out
+
+    def test_print_logo_shows_tagline(self, capsys):
+        print_logo()
+        captured = capsys.readouterr()
+        assert "AWS EC2 Instance Management" in captured.out
+
+    def test_print_logo_ends_with_blank_line(self, capsys):
+        print_logo()
+        captured = capsys.readouterr()
+        # Output should end with at least one blank line for spacing
+        assert captured.out.endswith("\n\n")
 
 
 class TestGetVersion:
@@ -87,7 +98,11 @@ class TestLogoIntegration:
         # Should not raise any exceptions
         print_logo()
 
-    def test_logo_works_with_all_options(self, capsys):
-        print_logo(show_version=True)
+    def test_logo_displays_complete_output(self, mocker, capsys):
+        mocker.patch("remote.logo.get_version", return_value="1.0.0")
+        print_logo()
         captured = capsys.readouterr()
-        assert captured.out  # Has output
+        # Should have logo, tagline, and version
+        assert "REMOTE" in captured.out or "██" in captured.out  # Logo chars
+        assert "AWS EC2 Instance Management" in captured.out
+        assert "v1.0.0" in captured.out


### PR DESCRIPTION
## Summary
- Center the logo based on terminal width
- Add "AWS EC2 Instance Management" tagline below the logo
- Always display version (removed `show_version` parameter)
- Add trailing blank line for visual separation from help text

## Test plan
- [x] All 785 tests pass
- [x] Visual verification with `remote --help`
- [x] Tested narrow terminal handling