### PR TITLE
fix(instance): Replace subprocess timeout with SSH keepalive for interactive sessions

### DIFF
--- a/remote/settings.py
+++ b/remote/settings.py
@@ -29,9 +29,15 @@ DEFAULT_EXEC_TIMEOUT_SECONDS = 30
 SSH_OPERATION_TIMEOUT_SECONDS = 30
 
 # SSH connect timeout (interactive sessions)
-# Longer timeout for interactive sessions since users may be slow to respond
-# to prompts, but still prevents indefinite hangs on network issues
-DEFAULT_SSH_CONNECT_TIMEOUT_SECONDS = 120
+# Default to 0 (no timeout) for interactive sessions since they run indefinitely.
+# Users can specify --timeout to set a maximum session duration if needed.
+# Dead connection detection is handled by SSH keepalive options instead.
+DEFAULT_SSH_CONNECT_TIMEOUT_SECONDS = 0
+
+# SSH keepalive settings for interactive sessions
+# These detect dead connections without killing active sessions
+SSH_SERVER_ALIVE_INTERVAL = 60  # Send keepalive every 60 seconds
+SSH_SERVER_ALIVE_COUNT_MAX = 3  # Disconnect after 3 missed keepalives (3 minutes)
 
 
 @dataclass

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -3305,6 +3305,9 @@ class TestBuildSshCommand:
         result_str = " ".join(result)
         assert "BatchMode" not in result_str
         assert "ConnectTimeout" not in result_str
+        # Should have keepalive options for interactive sessions
+        assert "ServerAliveInterval=60" in result_str
+        assert "ServerAliveCountMax=3" in result_str
 
     def test_should_add_port_forwarding_when_specified(self):
         """Should add -L flag with port forwarding specification."""
@@ -3343,6 +3346,9 @@ class TestBuildSshCommand:
         # Should NOT have BatchMode/ConnectTimeout due to interactive=True
         result_str = " ".join(result)
         assert "BatchMode" not in result_str
+        # Should have keepalive options for interactive sessions
+        assert "ServerAliveInterval=60" in result_str
+        assert "ServerAliveCountMax=3" in result_str
 
 
 class TestGetSshConfig:

--- a/uv.lock
+++ b/uv.lock
@@ -1131,7 +1131,7 @@ wheels = [
 
 [[package]]
 name = "remotepy"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Summary
- Default timeout changed to 0 (no subprocess timeout) for interactive sessions
- Added ServerAliveInterval=60 and ServerAliveCountMax=3 SSH options
- Dead connections now detected via SSH keepalive (~3 min of no response)
- Users can still set --timeout to limit max session duration if needed

## Problem
The SSH connect command previously used a 120-second subprocess timeout which would kill active sessions after 2 minutes. This caused SSH connections to drop unexpectedly during normal use.

## Test plan
- [x] All 785 tests pass
- [x] SSH-related tests specifically verified