### PR TITLE
fix(security): Add username validation to prevent command injection

### DIFF
--- a/remote/instance.py
+++ b/remote/instance.py
@@ -79,6 +79,7 @@ from remote.validation import (
     sanitize_input,
     validate_instance_type,
     validate_ssh_key_path,
+    validate_ssh_username,
 )
 
 app = typer.Typer()
@@ -1017,7 +1018,13 @@ def connect(
         "-p",
         help="Port forwarding configuration (local:remote)",
     ),
-    user: str = typer.Option(DEFAULT_SSH_USER, "--user", "-u", help="SSH username"),
+    user: str = typer.Option(
+        DEFAULT_SSH_USER,
+        "--user",
+        "-u",
+        callback=validate_ssh_username,
+        help="SSH/SSM username",
+    ),
     key: str | None = typer.Option(
         None,
         "--key",
@@ -1174,7 +1181,13 @@ def forward(
     instance_name: str | None = typer.Argument(
         None, help="Instance name (uses default if not provided)"
     ),
-    user: str = typer.Option(DEFAULT_SSH_USER, "--user", "-u", help="SSH username"),
+    user: str = typer.Option(
+        DEFAULT_SSH_USER,
+        "--user",
+        "-u",
+        callback=validate_ssh_username,
+        help="SSH/SSM username",
+    ),
     key: str | None = typer.Option(
         None,
         "--key",
@@ -1315,7 +1328,13 @@ def forward(
 def exec_command(
     ctx: typer.Context,
     instance_name: str | None = typer.Argument(None, help="Instance name"),
-    user: str = typer.Option(DEFAULT_SSH_USER, "--user", "-u", help="SSH username"),
+    user: str = typer.Option(
+        DEFAULT_SSH_USER,
+        "--user",
+        "-u",
+        callback=validate_ssh_username,
+        help="SSH/SSM username",
+    ),
     key: str | None = typer.Option(
         None,
         "--key",
@@ -1809,7 +1828,13 @@ def copy(
     destination: str = typer.Argument(
         ..., help="Destination path (local or instance-name:/remote/path)"
     ),
-    user: str = typer.Option(DEFAULT_SSH_USER, "--user", "-u", help="SSH username"),
+    user: str = typer.Option(
+        DEFAULT_SSH_USER,
+        "--user",
+        "-u",
+        callback=validate_ssh_username,
+        help="SSH/SSM username",
+    ),
     key: str | None = typer.Option(
         None,
         "--key",
@@ -1954,7 +1979,13 @@ def sync(
     destination: str = typer.Argument(
         ..., help="Destination path (local or instance-name:/remote/path)"
     ),
-    user: str = typer.Option(DEFAULT_SSH_USER, "--user", "-u", help="SSH username"),
+    user: str = typer.Option(
+        DEFAULT_SSH_USER,
+        "--user",
+        "-u",
+        callback=validate_ssh_username,
+        help="SSH/SSM username",
+    ),
     key: str | None = typer.Option(
         None,
         "--key",


### PR DESCRIPTION
## Summary

- Add `validate_ssh_username` callback to validate the `--user` CLI option
- Prevents command injection in SSM connections where username is interpolated into shell commands (`sudo su - {username}`)
- Applies validation to all 5 commands that accept `--user`: connect, exec, forward, copy, sync

## Security Issue

Without validation, a malicious username like `ubuntu; rm -rf /` could execute arbitrary commands on the remote instance when using SSM connection method:

```bash
remote instance connect --connection ssm -u 'ubuntu; cat /etc/passwd'
# Would execute: sudo su - ubuntu; cat /etc/passwd
```

## Changes

- **remote/validation.py**: Add `validate_ssh_username` function and constants (`USERNAME_PATTERN`, `USERNAME_MAX_LENGTH`)
- **remote/instance.py**: Add callback to all `--user` options across 5 commands
- **tests/test_validation.py**: Add 11 tests including property-based tests and shell metacharacter rejection tests

## Test plan

- [x] All 907 existing tests pass
- [x] 11 new tests for username validation pass
- [x] Property-based tests verify valid/invalid character handling
- [x] Shell metacharacters (`; | & $ \` ' " > < \n`) are rejected
- [x] Linting and formatting pass
- [x] Pre-commit hooks pass (mypy, bandit, ruff, pytest)