### PR TITLE
fix: Reuse existing unattached remotepy SG instead of failing

### DIFF
--- a/remote/sg.py
+++ b/remote/sg.py
@@ -550,6 +550,12 @@ def detach_security_group_from_instance(instance_id: str, sg_id: str) -> None:
 def find_or_create_remotepy_sg(instance_name: str, instance_id: str) -> str:
     """Find the remotepy-managed SG for an instance, or create and attach one.
 
+    Checks three places in order:
+    1. Security groups already attached to the instance
+    2. Unattached security groups in the same VPC (e.g. left over from a
+       previous instance with the same name)
+    3. Creates a new security group if none exists
+
     Args:
         instance_name: The instance name
         instance_id: The EC2 instance ID
@@ -565,8 +571,25 @@ def find_or_create_remotepy_sg(instance_name: str, instance_id: str) -> str:
         if sg["GroupName"] == sg_name:
             return str(sg["GroupId"])
 
-    # Not found — create, attach, and return
     vpc_id = get_instance_vpc_id(instance_id)
+
+    # Check if it exists in the VPC but isn't attached (e.g. from a replaced instance)
+    with handle_aws_errors("EC2", "describe_security_groups"):
+        response = get_ec2_client().describe_security_groups(
+            Filters=[
+                {"Name": "group-name", "Values": [sg_name]},
+                {"Name": "vpc-id", "Values": [vpc_id]},
+            ]
+        )
+
+    existing_sgs = response.get("SecurityGroups", [])
+    if existing_sgs:
+        sg_id = existing_sgs[0]["GroupId"]
+        attach_security_group_to_instance(instance_id, sg_id)
+        print_info(f"Attached existing managed security group {sg_name} ({sg_id})")
+        return sg_id
+
+    # Not found anywhere — create, attach, and return
     sg_id = create_instance_security_group(instance_name, vpc_id)
     attach_security_group_to_instance(instance_id, sg_id)
     print_info(f"Created managed security group {sg_name} ({sg_id})")

--- a/remote/sg.py
+++ b/remote/sg.py
@@ -584,13 +584,43 @@ def find_or_create_remotepy_sg(instance_name: str, instance_id: str) -> str:
 
     existing_sgs = response.get("SecurityGroups", [])
     if existing_sgs:
+        if len(existing_sgs) > 1:
+            print_warning(
+                f"Found {len(existing_sgs)} security groups named {sg_name} "
+                f"in VPC {vpc_id}; using {existing_sgs[0]['GroupId']}"
+            )
         sg_id = existing_sgs[0]["GroupId"]
+        # Clear stale inbound rules from the orphaned SG so it behaves
+        # the same as a freshly created one
+        stale_rules = get_security_group_rules(sg_id)
+        if stale_rules:
+            with handle_aws_errors("EC2", "revoke_security_group_ingress"):
+                get_ec2_client().revoke_security_group_ingress(
+                    GroupId=sg_id, IpPermissions=stale_rules
+                )
+            print_warning(
+                f"Cleared {len(stale_rules)} stale rule(s) from orphaned SG {sg_id}"
+            )
         attach_security_group_to_instance(instance_id, sg_id)
         print_info(f"Attached existing managed security group {sg_name} ({sg_id})")
         return sg_id
 
     # Not found anywhere — create, attach, and return
-    sg_id = create_instance_security_group(instance_name, vpc_id)
+    try:
+        sg_id = create_instance_security_group(instance_name, vpc_id)
+    except AWSServiceError as e:
+        if getattr(e, "aws_error_code", "") != "InvalidGroup.Duplicate":
+            raise
+        # Race condition: another process created the SG between our check and
+        # create. Look it up and attach the one that won the race.
+        with handle_aws_errors("EC2", "describe_security_groups"):
+            retry = get_ec2_client().describe_security_groups(
+                Filters=[
+                    {"Name": "group-name", "Values": [sg_name]},
+                    {"Name": "vpc-id", "Values": [vpc_id]},
+                ]
+            )
+        sg_id = retry["SecurityGroups"][0]["GroupId"]
     attach_security_group_to_instance(instance_id, sg_id)
     print_info(f"Created managed security group {sg_name} ({sg_id})")
     return sg_id

--- a/remote/sg.py
+++ b/remote/sg.py
@@ -598,9 +598,7 @@ def find_or_create_remotepy_sg(instance_name: str, instance_id: str) -> str:
                 get_ec2_client().revoke_security_group_ingress(
                     GroupId=sg_id, IpPermissions=stale_rules
                 )
-            print_warning(
-                f"Cleared {len(stale_rules)} stale rule(s) from orphaned SG {sg_id}"
-            )
+            print_warning(f"Cleared {len(stale_rules)} stale rule(s) from orphaned SG {sg_id}")
         attach_security_group_to_instance(instance_id, sg_id)
         print_info(f"Attached existing managed security group {sg_name} ({sg_id})")
         return sg_id

--- a/remote/sg.py
+++ b/remote/sg.py
@@ -596,7 +596,8 @@ def find_or_create_remotepy_sg(instance_name: str, instance_id: str) -> str:
         if stale_rules:
             with handle_aws_errors("EC2", "revoke_security_group_ingress"):
                 get_ec2_client().revoke_security_group_ingress(
-                    GroupId=sg_id, IpPermissions=stale_rules
+                    GroupId=sg_id,
+                    IpPermissions=stale_rules,  # type: ignore[arg-type]
                 )
             print_warning(f"Cleared {len(stale_rules)} stale rule(s) from orphaned SG {sg_id}")
         attach_security_group_to_instance(instance_id, sg_id)

--- a/tests/test_sg.py
+++ b/tests/test_sg.py
@@ -425,9 +425,7 @@ class TestFindOrCreateRemotepySg:
         mocker.patch("remote.sg.get_instance_vpc_id", return_value="vpc-12345")
         mock_ec2 = mocker.patch("remote.sg.get_ec2_client")
         mock_ec2.return_value.describe_security_groups.return_value = {
-            "SecurityGroups": [
-                {"GroupId": "sg-orphan", "GroupName": "remotepy-my-instance"}
-            ]
+            "SecurityGroups": [{"GroupId": "sg-orphan", "GroupName": "remotepy-my-instance"}]
         }
         mocker.patch("remote.sg.get_security_group_rules", return_value=[])
         mock_create = mocker.patch("remote.sg.create_instance_security_group")
@@ -452,9 +450,7 @@ class TestFindOrCreateRemotepySg:
         mocker.patch("remote.sg.get_instance_vpc_id", return_value="vpc-12345")
         mock_ec2 = mocker.patch("remote.sg.get_ec2_client")
         mock_ec2.return_value.describe_security_groups.return_value = {
-            "SecurityGroups": [
-                {"GroupId": "sg-orphan", "GroupName": "remotepy-my-instance"}
-            ]
+            "SecurityGroups": [{"GroupId": "sg-orphan", "GroupName": "remotepy-my-instance"}]
         }
         stale_rules = [
             {
@@ -474,9 +470,7 @@ class TestFindOrCreateRemotepySg:
         mock_ec2.return_value.revoke_security_group_ingress.assert_called_once_with(
             GroupId="sg-orphan", IpPermissions=stale_rules
         )
-        mock_warning.assert_called_once_with(
-            "Cleared 1 stale rule(s) from orphaned SG sg-orphan"
-        )
+        mock_warning.assert_called_once_with("Cleared 1 stale rule(s) from orphaned SG sg-orphan")
 
     def test_warns_on_multiple_matching_sgs(self, mocker):
         """Test warning when multiple SGs with same name exist in VPC."""
@@ -500,8 +494,7 @@ class TestFindOrCreateRemotepySg:
 
         assert result == "sg-first"
         mock_warning.assert_any_call(
-            "Found 2 security groups named remotepy-my-instance "
-            "in VPC vpc-12345; using sg-first"
+            "Found 2 security groups named remotepy-my-instance in VPC vpc-12345; using sg-first"
         )
 
     def test_handles_duplicate_race_condition(self, mocker):
@@ -521,7 +514,9 @@ class TestFindOrCreateRemotepySg:
         mocker.patch(
             "remote.sg.create_instance_security_group",
             side_effect=AWSServiceError(
-                "EC2", "create_security_group", "InvalidGroup.Duplicate",
+                "EC2",
+                "create_security_group",
+                "InvalidGroup.Duplicate",
                 "The security group already exists",
             ),
         )
@@ -540,9 +535,7 @@ class TestFindOrCreateRemotepySg:
         )
         mocker.patch("remote.sg.get_instance_vpc_id", return_value="vpc-12345")
         mock_ec2 = mocker.patch("remote.sg.get_ec2_client")
-        mock_ec2.return_value.describe_security_groups.return_value = {
-            "SecurityGroups": []
-        }
+        mock_ec2.return_value.describe_security_groups.return_value = {"SecurityGroups": []}
         mocker.patch("remote.sg.create_instance_security_group", return_value="sg-new123")
         mock_attach = mocker.patch("remote.sg.attach_security_group_to_instance")
 

--- a/tests/test_sg.py
+++ b/tests/test_sg.py
@@ -414,13 +414,39 @@ class TestFindOrCreateRemotepySg:
         assert result == "sg-rpy"
         mock_create.assert_not_called()
 
-    def test_creates_and_attaches_when_missing(self, mocker):
-        """Test that a new SG is created and attached when not found."""
+    def test_finds_existing_unattached_sg_in_vpc(self, mocker):
+        """Test that an existing unattached SG in the VPC is found and attached."""
         mocker.patch(
             "remote.sg.get_instance_security_groups",
             return_value=[{"GroupId": "sg-existing", "GroupName": "default"}],
         )
         mocker.patch("remote.sg.get_instance_vpc_id", return_value="vpc-12345")
+        mock_ec2 = mocker.patch("remote.sg.get_ec2_client")
+        mock_ec2.return_value.describe_security_groups.return_value = {
+            "SecurityGroups": [
+                {"GroupId": "sg-orphan", "GroupName": "remotepy-my-instance"}
+            ]
+        }
+        mock_create = mocker.patch("remote.sg.create_instance_security_group")
+        mock_attach = mocker.patch("remote.sg.attach_security_group_to_instance")
+
+        result = find_or_create_remotepy_sg("my-instance", "i-12345")
+
+        assert result == "sg-orphan"
+        mock_attach.assert_called_once_with("i-12345", "sg-orphan")
+        mock_create.assert_not_called()
+
+    def test_creates_and_attaches_when_missing(self, mocker):
+        """Test that a new SG is created and attached when not found anywhere."""
+        mocker.patch(
+            "remote.sg.get_instance_security_groups",
+            return_value=[{"GroupId": "sg-existing", "GroupName": "default"}],
+        )
+        mocker.patch("remote.sg.get_instance_vpc_id", return_value="vpc-12345")
+        mock_ec2 = mocker.patch("remote.sg.get_ec2_client")
+        mock_ec2.return_value.describe_security_groups.return_value = {
+            "SecurityGroups": []
+        }
         mocker.patch("remote.sg.create_instance_security_group", return_value="sg-new123")
         mock_attach = mocker.patch("remote.sg.attach_security_group_to_instance")
 

--- a/tests/test_sg.py
+++ b/tests/test_sg.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 from typer.testing import CliRunner
 
-from remote.exceptions import ValidationError
+from remote.exceptions import AWSServiceError, ValidationError
 from remote.sg import (
     add_ip_to_security_group,
     app,
@@ -398,8 +398,8 @@ class TestClearPortRules:
 class TestFindOrCreateRemotepySg:
     """Tests for find_or_create_remotepy_sg function."""
 
-    def test_returns_existing_sg(self, mocker):
-        """Test that existing remotepy SG is returned without creating."""
+    def test_returns_existing_sg_without_vpc_lookup(self, mocker):
+        """Test that existing attached SG is returned without VPC lookup or creation."""
         mocker.patch(
             "remote.sg.get_instance_security_groups",
             return_value=[
@@ -408,11 +408,13 @@ class TestFindOrCreateRemotepySg:
             ],
         )
         mock_create = mocker.patch("remote.sg.create_instance_security_group")
+        mock_vpc = mocker.patch("remote.sg.get_instance_vpc_id")
 
         result = find_or_create_remotepy_sg("my-instance", "i-12345")
 
         assert result == "sg-rpy"
         mock_create.assert_not_called()
+        mock_vpc.assert_not_called()
 
     def test_finds_existing_unattached_sg_in_vpc(self, mocker):
         """Test that an existing unattached SG in the VPC is found and attached."""
@@ -427,14 +429,108 @@ class TestFindOrCreateRemotepySg:
                 {"GroupId": "sg-orphan", "GroupName": "remotepy-my-instance"}
             ]
         }
+        mocker.patch("remote.sg.get_security_group_rules", return_value=[])
         mock_create = mocker.patch("remote.sg.create_instance_security_group")
         mock_attach = mocker.patch("remote.sg.attach_security_group_to_instance")
+        mock_info = mocker.patch("remote.sg.print_info")
 
         result = find_or_create_remotepy_sg("my-instance", "i-12345")
 
         assert result == "sg-orphan"
         mock_attach.assert_called_once_with("i-12345", "sg-orphan")
         mock_create.assert_not_called()
+        mock_info.assert_called_once_with(
+            "Attached existing managed security group remotepy-my-instance (sg-orphan)"
+        )
+
+    def test_clears_stale_rules_from_orphaned_sg(self, mocker):
+        """Test that stale inbound rules are cleared from an orphaned SG before reuse."""
+        mocker.patch(
+            "remote.sg.get_instance_security_groups",
+            return_value=[{"GroupId": "sg-existing", "GroupName": "default"}],
+        )
+        mocker.patch("remote.sg.get_instance_vpc_id", return_value="vpc-12345")
+        mock_ec2 = mocker.patch("remote.sg.get_ec2_client")
+        mock_ec2.return_value.describe_security_groups.return_value = {
+            "SecurityGroups": [
+                {"GroupId": "sg-orphan", "GroupName": "remotepy-my-instance"}
+            ]
+        }
+        stale_rules = [
+            {
+                "IpProtocol": "tcp",
+                "FromPort": 22,
+                "ToPort": 22,
+                "IpRanges": [{"CidrIp": "1.2.3.4/32"}],
+            }
+        ]
+        mocker.patch("remote.sg.get_security_group_rules", return_value=stale_rules)
+        mocker.patch("remote.sg.attach_security_group_to_instance")
+        mock_warning = mocker.patch("remote.sg.print_warning")
+
+        result = find_or_create_remotepy_sg("my-instance", "i-12345")
+
+        assert result == "sg-orphan"
+        mock_ec2.return_value.revoke_security_group_ingress.assert_called_once_with(
+            GroupId="sg-orphan", IpPermissions=stale_rules
+        )
+        mock_warning.assert_called_once_with(
+            "Cleared 1 stale rule(s) from orphaned SG sg-orphan"
+        )
+
+    def test_warns_on_multiple_matching_sgs(self, mocker):
+        """Test warning when multiple SGs with same name exist in VPC."""
+        mocker.patch(
+            "remote.sg.get_instance_security_groups",
+            return_value=[{"GroupId": "sg-existing", "GroupName": "default"}],
+        )
+        mocker.patch("remote.sg.get_instance_vpc_id", return_value="vpc-12345")
+        mock_ec2 = mocker.patch("remote.sg.get_ec2_client")
+        mock_ec2.return_value.describe_security_groups.return_value = {
+            "SecurityGroups": [
+                {"GroupId": "sg-first", "GroupName": "remotepy-my-instance"},
+                {"GroupId": "sg-second", "GroupName": "remotepy-my-instance"},
+            ]
+        }
+        mocker.patch("remote.sg.get_security_group_rules", return_value=[])
+        mocker.patch("remote.sg.attach_security_group_to_instance")
+        mock_warning = mocker.patch("remote.sg.print_warning")
+
+        result = find_or_create_remotepy_sg("my-instance", "i-12345")
+
+        assert result == "sg-first"
+        mock_warning.assert_any_call(
+            "Found 2 security groups named remotepy-my-instance "
+            "in VPC vpc-12345; using sg-first"
+        )
+
+    def test_handles_duplicate_race_condition(self, mocker):
+        """Test that InvalidGroup.Duplicate is handled when another process wins the race."""
+        mocker.patch(
+            "remote.sg.get_instance_security_groups",
+            return_value=[{"GroupId": "sg-existing", "GroupName": "default"}],
+        )
+        mocker.patch("remote.sg.get_instance_vpc_id", return_value="vpc-12345")
+        mock_ec2 = mocker.patch("remote.sg.get_ec2_client")
+        # First describe returns empty (triggering create path)
+        # Second describe (after race) returns the SG that won
+        mock_ec2.return_value.describe_security_groups.side_effect = [
+            {"SecurityGroups": []},
+            {"SecurityGroups": [{"GroupId": "sg-raced", "GroupName": "remotepy-my-instance"}]},
+        ]
+        mocker.patch(
+            "remote.sg.create_instance_security_group",
+            side_effect=AWSServiceError(
+                "EC2", "create_security_group", "InvalidGroup.Duplicate",
+                "The security group already exists",
+            ),
+        )
+        mock_attach = mocker.patch("remote.sg.attach_security_group_to_instance")
+
+        result = find_or_create_remotepy_sg("my-instance", "i-12345")
+
+        assert result == "sg-raced"
+        mock_attach.assert_called_once_with("i-12345", "sg-raced")
 
     def test_creates_and_attaches_when_missing(self, mocker):
         """Test that a new SG is created and attached when not found anywhere."""


### PR DESCRIPTION
## Summary

Fixes #85.

- `find_or_create_remotepy_sg()` now checks for an existing `remotepy-{name}` security group in the VPC before attempting to create a new one
- If an unattached SG is found (e.g. left over from a terminated instance with the same name), it is attached to the instance and reused
- Only creates a new SG if none exists anywhere in the VPC

## Test plan

- [x] New test: `test_finds_existing_unattached_sg_in_vpc` — verifies the VPC lookup and attach path
- [x] Updated test: `test_creates_and_attaches_when_missing` — now also mocks the VPC lookup returning empty results
- [x] All 1119 tests pass, linting clean